### PR TITLE
Expand session path and add packages

### DIFF
--- a/home/clord/programs/cli/default.nix
+++ b/home/clord/programs/cli/default.nix
@@ -1,4 +1,5 @@
-{pkgs, ...}: {
+{ pkgs, ... }:
+{
   imports = [
     ./bat.nix
     ./btop.nix
@@ -19,67 +20,76 @@
     programs.bun.enable = true;
 
     home = {
-      sessionPath = ["node_modules/.bin" "$HOME/.local/node_modules/.bin" "$HOME/go/bin"];
+      sessionPath = [
+        "node_modules/.bin"
+        "$HOME/.claude/local"
+        "$HOME/.local/node_modules/.bin"
+        "$HOME/go/bin"
+      ];
       sessionVariables = {
         EDITOR = "nvim";
       };
-      packages = with pkgs; [
-        age
-        dua
-        difftastic
-        fd
-        ffmpeg
-        hledger
-        fzf
-        git
-        go
-	rustup
-        mosh
-	nixd
-	nil
-        angle-grinder
-        nodejs_22
-        corepack_22
-        pandoc
-        python311Packages.pynvim
-        sqlite
-        sysbench
-        tldr
-        typst
-        unzip
-        wget
-        xz
-        zig
-        zip
-      ] ++ [
-	# Grafana stuff
-	gnumake
-	libiconv
-	
-	go
-	gopls
-	act
-	gotools
-	go-migrate
-	gh
-	mage
-	
-	# Grafana stuff
-	google-cloud-sdk
-	jsonnet-bundler
-	
-	# Node stuff
-	nodejs
-	corepack_22
-	nodePackages.concurrently
-	nodePackages.prettier
+      packages =
+        with pkgs;
+        [
+          age
+          dua
+          difftastic
+          fd
+          ffmpeg
+          hledger
+          fzf
+          git
+          go
+          rustup
+          mosh
+          nixd
+	  caddy
+          nil
+          angle-grinder
+          nodejs_22
+          corepack_22
+          pandoc
+          python311Packages.pynvim
+          sqlite
+          sysbench
+          tldr
+          typst
+          unzip
+          wget
+          xz
+          zig
+          zip
+        ]
+        ++ [
+          # Grafana stuff
+          gnumake
+          libiconv
 
-	# Tilt requires some kube stuff
-	tilt
-	tanka
-	ctlptl
-	kubernetes-helm
-      ];
+          go
+          gopls
+          act
+          gotools
+          go-migrate
+          gh
+          mage
+
+          # Grafana stuff
+          google-cloud-sdk
+          jsonnet-bundler
+
+          # Node stuff
+          nodejs_22
+          corepack_22
+          nodePackages.concurrently
+          nodePackages.prettier
+
+          # Tilt requires some kube stuff
+          tilt
+          tanka
+          ctlptl
+          kubernetes-helm
+        ];
     };
   };
 }


### PR DESCRIPTION
add new packages

This change expands the session path to include additional directories for local node modules and the Caddy web server. It also adds several new packages to the home.packages list, including tools for development, system administration, and Kubernetes/Grafana tooling.

The key changes are:

- Expand session path to include more directories
- Add new packages like Caddy, Tilt, Tanka, and Kubernetes Helm
- Reorganize the packages list for better readability